### PR TITLE
feat: do not run the workflow on non-dependabot branch

### DIFF
--- a/.github/workflows/auto-merge-dependabot-pr.yaml
+++ b/.github/workflows/auto-merge-dependabot-pr.yaml
@@ -4,7 +4,10 @@
 name: Auto-merge Dependabot PR
 
 # Run when a pull request is opened or updated
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - "dependabot/**"
 
 permissions:
   # Needed to read the repository and merge the PR


### PR DESCRIPTION
This should prevent the workflow from being run on branches which are not dependabot.